### PR TITLE
added unavailable dates generator for pup model and added to show view

### DIFF
--- a/app/models/pup.rb
+++ b/app/models/pup.rb
@@ -15,4 +15,23 @@ class Pup < ApplicationRecord
     reviews.each { |review| average += review.rating }
     (average / reviews.count).floor
   end
+
+  def unavailable_dates
+    unavailable_dates = []
+    bookings.each do |booking|
+      finished = false
+      end_time = booking.time_end.to_date
+      start_time = booking.time_start.to_date
+
+      until finished
+        unavailable_dates << end_time
+        if end_time == start_time
+          finished = true
+        else
+          end_time = end_time.prev_day
+        end
+      end
+    end
+    unavailable_dates
+  end
 end

--- a/app/views/api/v1/pups/show.json.jbuilder
+++ b/app/views/api/v1/pups/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! @pup, :id, :name, :location, :description, :image, :price, :avg_rating
+json.extract! @pup, :id, :name, :location, :description, :image, :price, :avg_rating, :unavailable_dates
   json.reviews @pup.reviews do |review| #is pup.bookings.reviews or pup.reviews?
     json.extract! review, :content, :rating
     json.date review.created_at.strftime('%m/%d/%y')


### PR DESCRIPTION
Allows us to paint the calendar in the show view of the mini app with unavailable dates. Basically takes each booking and adds the unavailable dates to a array which we pass to the pup show view.